### PR TITLE
update dependencies to fix bignum deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "bn.js": "^5.2.2",
         "bufferutil": "^4.0.8",
         "cli-color": "^2.0.3",
-        "cryptoforknote-util": "git+https://github.com/MoneroOcean/node-cryptoforknote-util.git",
+        "cryptoforknote-util": "git+https://github.com/Acktarius/node-cryptoforknote-util.git",
         "cryptonight-hashing": "git+https://github.com/Acktarius/cryptonight-hashing.git",
         "dateformat": "^4.6.3",
         "mailgun.js": "^11.1.0",


### PR DESCRIPTION
migrate to in house patched version of dependency: **node-cryptoforknote-util**, to solve vulnerability with **bignum**